### PR TITLE
Reset exit code at end of file

### DIFF
--- a/secureboot.sh
+++ b/secureboot.sh
@@ -337,3 +337,5 @@ esac
 (( INIT )) && initialize
 (( SIGN )) && sign
 (( ENROLL_KEYS )) && enroll_keys
+
+exit 0


### PR DESCRIPTION
This prevents a failed check for a a different function to cause a non-zero exit code even though the function being executed is successful.

This closes #1 